### PR TITLE
feat(CC-9729) Make PROSE_SERVICE_URI configurable

### DIFF
--- a/lib/collab/js.rb
+++ b/lib/collab/js.rb
@@ -76,7 +76,7 @@ module Collab
       end
 
       def api_client
-        @api_client ||= ApiClient::Collab.new
+        @api_client ||= ApiClient::Collab.new service_uri: ENV.fetch('PROSE_SERVICE_URI', 'http://localhost:8282')
       end
 
       def html_to_document(html, schema_name:)

--- a/lib/collab/models/document.rb
+++ b/lib/collab/models/document.rb
@@ -102,7 +102,7 @@ module Collab
       end
 
       def api_client
-        @api_client ||= ApiClient::Collab.new
+        @api_client ||= ApiClient::Collab.new service_uri: ENV.fetch('PROSE_SERVICE_URI', 'http://localhost:8282')
       end
 
       def from_html(html)


### PR DESCRIPTION
Passes ENV var `PROSE_SERVICE_URI` to `ApiClient` initializer