### PR TITLE
chore(CC-9729) cleaner init of service_uri

### DIFF
--- a/lib/api_client/collab.rb
+++ b/lib/api_client/collab.rb
@@ -6,5 +6,9 @@ module ApiClient
   # ruby-client of server-authority for client-library: prosemirror-collab-plus
   class Collab < Base
     config.base_path = '/'
+
+    def initializer(**kwargs)
+      @service_uri = kwargs[:service_uri] || 'http://localhost:8282'
+    end
   end
 end

--- a/lib/collab/js.rb
+++ b/lib/collab/js.rb
@@ -76,7 +76,7 @@ module Collab
       end
 
       def api_client
-        @api_client ||= ApiClient::Collab.new service_uri: ENV.fetch('PROSE_SERVICE_URI', 'http://localhost:8282')
+        @api_client ||= ApiClient::Collab.new
       end
 
       def html_to_document(html, schema_name:)

--- a/lib/collab/models/document.rb
+++ b/lib/collab/models/document.rb
@@ -102,7 +102,7 @@ module Collab
       end
 
       def api_client
-        @api_client ||= ApiClient::Collab.new service_uri: ENV.fetch('PROSE_SERVICE_URI', 'http://localhost:8282')
+        @api_client ||= ApiClient::Collab.new
       end
 
       def from_html(html)


### PR DESCRIPTION
Initialize `service_uri` from the app-layer instead of explicitly relying on the ENV