### PR TITLE
chore: update Faraday

### DIFF
--- a/collab.gemspec
+++ b/collab.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   # spec.description   = %q{TODO: Write a longer description or delete this line.}
   spec.homepage      = 'https://github.com/benaubin/rails-collab'
   spec.license       = 'MIT'
-  spec.required_ruby_version = Gem::Requirement.new('>= 2.3.0')
+  spec.required_ruby_version = Gem::Requirement.new('>= 3.0.6')
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/benaubin/rails-collab'
@@ -25,9 +25,10 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{app,config,db,lib}/**/*', 'Rakefile']
 
   spec.add_dependency 'rails', '~> 7.1.0'
-  spec.add_dependency 'faraday', '~> 1.10.2'
-  spec.add_dependency 'faraday_middleware', '~> 1.2.0'
-  spec.add_dependency 'faraday-encoding', '~> 0.0.5'
+  spec.add_dependency 'faraday', '~> 2.14.1'
+  spec.add_dependency 'faraday-retry', '~> 2.2'
+  # Note: Faraday 2 no longer uses `faraday_middleware` (which is Faraday 1.x only).
+  # Keep middleware usage minimal and rely on Faraday core + `faraday-retry`.
 
   # allow for adapter of choice
   # spec.add_dependency 'faraday-httpclient', '~> 1.0.1'

--- a/lib/collab/version.rb
+++ b/lib/collab/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Collab
-  VERSION = '0.5.0'
+  VERSION = '0.5.1'
 end


### PR DESCRIPTION
There is CVE in versions of Faraday less than 2.14.1. Updating also required to update Ruby to >= 3. See: https://github.com/lostisland/faraday/security/advisories/GHSA-33mh-2634-fwr2