### PR TITLE
chore: Fix Faraday middleware

### DIFF
--- a/lib/api_client/base.rb
+++ b/lib/api_client/base.rb
@@ -3,6 +3,7 @@
 require 'active_support/configurable'
 require 'faraday'
 require 'faraday/retry'
+require 'faraday/request/instrumentation'
 require 'set'
 
 # ORM-ish for data-transfer between services
@@ -66,8 +67,8 @@ module ApiClient
     # https://github.com/lostisland/awesome-faraday/#middleware
     # https://lostisland.github.io/faraday/middleware/instrumentation
     config.default_middlewares = Set.new(
-      %i[
-        instrumentation
+      [
+        Faraday::Request::Instrumentation
       ]
     )
 


### PR DESCRIPTION
The middleware was moved in Faraday 2.0, Instrumentation is now a part of Faraday and we were accessing it incorrectly. This will fix that issue. see: https://github.com/lostisland/faraday/blob/main/UPGRADING.md